### PR TITLE
avoid method conflict

### DIFF
--- a/sample_input/InvalidClass.java
+++ b/sample_input/InvalidClass.java
@@ -1,0 +1,15 @@
+package jp.naist.sd.kenja.factextractor.test;
+
+public class InvalidClass {
+	private int intField;
+	private int intField;
+
+	public void invalidMethod() {
+
+	}
+
+	public void invalidMethod() {
+
+	}
+
+}

--- a/src/main/java/jp/naist/sd/kenja/factextractor/ast/ASTClass.java
+++ b/src/main/java/jp/naist/sd/kenja/factextractor/ast/ASTClass.java
@@ -10,6 +10,9 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
 public class ASTClass extends ASTType {
 
 	private final String FIELD_ROOT_NAME = "[FE]";
@@ -35,6 +38,7 @@ public class ASTClass extends ASTType {
 		root.append(constructorRoot);
 
 		//HashSet<String> tmpHashSet = new HashSet<String>();
+		Multimap<String, ASTMethod> methodMap = HashMultimap.create();
 		for (MethodDeclaration methodDec : typeDec.getMethods()) {
 			//if(tmpHashSet.contains(methodDec.getName().toString())){
 			//	System.out.println(methodDec.getName());
@@ -42,11 +46,20 @@ public class ASTClass extends ASTType {
 			//}
 			//tmpHashSet.add(methodDec.getName().toString());
 			ASTMethod method = ASTMethod.fromMethodDeclaralation(methodDec);
+
 			if(method.isConstructor()){
 				constructorRoot.append(method.getTree());
 			}
 			else{
 				methodRoot.append(method.getTree());
+				if (methodMap.containsKey(method.getName())) {
+					int i = 0;
+					for (ASTMethod astMethod : methodMap.get(method.getName())) {
+						astMethod.conflict(i++);
+					}
+					method.conflict(i);
+				}
+				methodMap.put(method.getName(), method);
 			}
 			// TODO overload methods
 		}

--- a/src/main/java/jp/naist/sd/kenja/factextractor/ast/ASTMethod.java
+++ b/src/main/java/jp/naist/sd/kenja/factextractor/ast/ASTMethod.java
@@ -21,12 +21,15 @@ public class ASTMethod implements Treeable{
 	
 	private boolean isConstructor;
 	
+	private String rootTreeName;
+
 	protected ASTMethod(){
 		
 	}
 	
 	protected ASTMethod(MethodDeclaration node){
-		root = new Tree(getTreeName(node));
+		rootTreeName = getTreeName(node);
+		root = new Tree(rootTreeName);
 		
 		isConstructor = node.isConstructor();
 		setBody(node);
@@ -74,6 +77,18 @@ public class ASTMethod implements Treeable{
 		parameters.setBody(parameterBody);
 	}
 	
+	public String getName() {
+		return rootTreeName;
+	}
+
+	public void conflict(int number) {
+		StringBuilder builder = new StringBuilder();
+		builder.append(rootTreeName);
+		builder.append(".conflicted");
+		builder.append(number);
+		root.setName(builder.toString());
+	}
+
 	public boolean isConstructor(){
 		return isConstructor;
 	}


### PR DESCRIPTION
Kenja will make "foobar().conflictedX" if method foobar is declared in same class.
This pull request will close #4 .
