### PR TITLE
supported parsing multiple blobs

### DIFF
--- a/src/main/java/jp/naist/sd/kenja/factextractor/GitTreeCreator.java
+++ b/src/main/java/jp/naist/sd/kenja/factextractor/GitTreeCreator.java
@@ -52,6 +52,7 @@ public class GitTreeCreator {
 
       for (String line : IOUtils.readLines(System.in)) {
         line = StringUtils.strip(line);
+        root = new Tree("");
 
         ObjectId obj = ObjectId.fromString(line);
         ObjectLoader loader = repo.open(obj);

--- a/src/main/java/jp/naist/sd/kenja/factextractor/GitTreeCreator.java
+++ b/src/main/java/jp/naist/sd/kenja/factextractor/GitTreeCreator.java
@@ -1,6 +1,8 @@
 package jp.naist.sd.kenja.factextractor;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStreamReader;
 import java.io.IOException;
 
 import jp.naist.sd.kenja.factextractor.ast.ASTCompilation;
@@ -50,8 +52,9 @@ public class GitTreeCreator {
     try {
       Repository repo = new FileRepository(repoDir);
 
-      for (String line : IOUtils.readLines(System.in)) {
-        line = StringUtils.strip(line);
+      BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+      String line;
+      while ( (line = br.readLine()) != null) {
         root = new Tree("");
 
         ObjectId obj = ObjectId.fromString(line);
@@ -60,7 +63,6 @@ public class GitTreeCreator {
         char[] src = IOUtils.toCharArray(loader.openStream());
         File outputFile = new File(syntaxTreeDirPath, line);
         parseSourcecodeAndWriteSyntaxTree(src, outputFile);
-
       }
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/main/java/jp/naist/sd/kenja/factextractor/GitTreeCreator.java
+++ b/src/main/java/jp/naist/sd/kenja/factextractor/GitTreeCreator.java
@@ -6,10 +6,15 @@ import java.io.IOException;
 import jp.naist.sd.kenja.factextractor.ast.ASTCompilation;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectLoader;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepository;
 
 public class GitTreeCreator {
   private Tree root = new Tree("");
@@ -30,6 +35,38 @@ public class GitTreeCreator {
     compilation = new ASTCompilation(unit, root);
   }
 
+  private void parseSourcecodeAndWriteSyntaxTree(char[] src, String outputPath) {
+    File outputFile = new File(outputPath);
+    parseSourcecodeAndWriteSyntaxTree(src, outputFile);
+  }
+
+  private void parseSourcecodeAndWriteSyntaxTree(char[] src, File outputFile) {
+    parseSourcecode(src);
+    writeASTAsFileTree(outputFile);
+  }
+
+  private void parseBlobs(String repositoryPath, String syntaxTreeDirPath) {
+    File repoDir = new File(repositoryPath);
+    try {
+      Repository repo = new FileRepository(repoDir);
+
+      for (String line : IOUtils.readLines(System.in)) {
+        line = StringUtils.strip(line);
+
+        ObjectId obj = ObjectId.fromString(line);
+        ObjectLoader loader = repo.open(obj);
+
+        char[] src = IOUtils.toCharArray(loader.openStream());
+        File outputFile = new File(syntaxTreeDirPath, line);
+        parseSourcecodeAndWriteSyntaxTree(src, outputFile);
+
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+  }
+
   public void writeASTAsFileTree(File outputFile) {
     try {
       TreeWriter writer = new TextFormatTreeWriter(outputFile);
@@ -40,19 +77,23 @@ public class GitTreeCreator {
   }
 
   public static void main(String[] args) {
-    if (args.length != 1) {
-      System.out.println("please input path of output file.");
+    if (args.length > 2) {
+      System.out.println("Usage(1): path_of_output_file");
+      System.out.println("Usage(2); path_of_git_repository path_of_syntax_trees_dir");
       return;
     }
 
-    File outputFile = new File(args[0]);
     GitTreeCreator creator = new GitTreeCreator();
 
-    try {
-      creator.parseSourcecode(IOUtils.toCharArray(System.in));
-      creator.writeASTAsFileTree(outputFile);
-    } catch (IOException e) {
-      e.printStackTrace();
+    if (args.length == 1) {
+      try {
+        char[] src = IOUtils.toCharArray(System.in);
+        creator.parseSourcecodeAndWriteSyntaxTree(src, args[0]);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    } else {
+      creator.parseBlobs(args[0], args[1]);
     }
   }
 }


### PR DESCRIPTION
Kenja java parser changes its behaviour depends on program arguments now.
If it gets only one arg (old style):
- read all lines from stdin and regards as source code.
- kenja-java-parser will output a syntax tree file which path was given as a argument.

If it gets two args (new added):
- read lines per line
- each line means hash of blob to parse.
- kenja-java-parser will read the contents of blob by using jGit API.
- the location of git repository is given as first argument.
- the location of syntax trees dir is given as second argument.
- kenja-java-parser automatically make syntax tree files in syntax trees dir and these file name is same as hash of blob.